### PR TITLE
Custom authentication-exception to override 'toString'-function

### DIFF
--- a/auth/src/core/exceptions/authentication-exception.ts
+++ b/auth/src/core/exceptions/authentication-exception.ts
@@ -1,0 +1,7 @@
+import { BaseException } from './base-exception';
+
+export class AuthenticationException extends BaseException {
+    public toString(): string {
+        return this.message;
+    }
+}


### PR DESCRIPTION
Adds an `AuthenticationException`, that overrides the `toString`-function to show only an error-message (without the prefix `Error: `).

In addition to [openslides-client#137](https://github.com/OpenSlides/openslides-client/pull/137)