### PR TITLE
Remove invalid cookies

### DIFF
--- a/auth/src/api/services/ticket-service.ts
+++ b/auth/src/api/services/ticket-service.ts
@@ -104,6 +104,6 @@ export class TicketService extends TicketHandler {
     private generateCookie(sessionId: string | JwtPayload, userId?: string): Cookie {
         const payload: JwtPayload =
             typeof sessionId === 'string' && userId ? { sessionId, userId } : (sessionId as JwtPayload);
-        return new Cookie(payload, this.cookieSecret, { expiresIn: '1d' });
+        return new Cookie(payload, this.cookieSecret, { expiresIn: '30d' });
     }
 }

--- a/auth/src/express/middleware/ticket-validator.ts
+++ b/auth/src/express/middleware/ticket-validator.ts
@@ -90,6 +90,7 @@ export class TicketMiddleware implements RestMiddleware {
             Logger.debug(e);
             if (e instanceof TokenExpiredError) {
                 Logger.debug('Cookie jwt is expired. Treat it like an anonymous.');
+                response.clearCookie(AuthHandler.COOKIE_NAME);
                 response.json(createResponse(anonymous, 'anonymous'));
             } else {
                 const { status, message }: ExpressError = e as ExpressError;


### PR DESCRIPTION
After the cookie expired, it was not cleared, so it was also sent in all subsequent requests which lead to the 403's in the AU service. I fixed that and increased the timeout to 30 days. Settings it to indefinetely seems to be bad practice so we should not do that. For example, OAuth tokens are valid for 60 days, so I think 30 days should be a good compromise.

If you want to test this PR, set the timeout to something small (like 10s), login to your dev setup, wait the chosen time and then click something. You should be redirected to the logout, with no further AU errors.