### PR TITLE
Fix typing of user id & access of users by id

### DIFF
--- a/auth/src/adapter/redis-database-adapter.ts
+++ b/auth/src/adapter/redis-database-adapter.ts
@@ -1,6 +1,6 @@
 import Redis from 'ioredis';
 
-import { Database } from '../api/interfaces/database';
+import { Database, KeyType } from '../api/interfaces/database';
 import { Logger } from '../api/services/logger';
 
 export class RedisDatabaseAdapter extends Database {
@@ -30,7 +30,7 @@ export class RedisDatabaseAdapter extends Database {
         });
     }
 
-    public async set<T>(key: string, obj: T): Promise<void> {
+    public async set<T>(key: KeyType, obj: T): Promise<void> {
         await new Promise((resolve, reject) => {
             this._database.hset(this.getHashKey(), this.getPrefixedKey(key), JSON.stringify(obj), (error, result) => {
                 if (error) {
@@ -49,7 +49,7 @@ export class RedisDatabaseAdapter extends Database {
         });
     }
 
-    public async get<T>(key: string): Promise<T> {
+    public async get<T>(key: KeyType): Promise<T> {
         return new Promise((resolve, reject) => {
             this._database.hget(this.getHashKey(), this.getPrefixedKey(key), (error, result) => {
                 if (error) {
@@ -66,7 +66,7 @@ export class RedisDatabaseAdapter extends Database {
         });
     }
 
-    public async remove(key: string): Promise<boolean> {
+    public async remove(key: KeyType): Promise<boolean> {
         const isDeleted = new Promise<boolean>((resolve, reject) => {
             this._database.hdel(this.getHashKey(), [this.getPrefixedKey(key)], (error, result) => {
                 if (error) {
@@ -108,7 +108,7 @@ export class RedisDatabaseAdapter extends Database {
         return `${Database.PREFIX}:${this.prefix}`;
     }
 
-    private getPrefixedKey(key: string): string {
+    private getPrefixedKey(key: KeyType): string {
         return `${this.getPrefix()}:${key}`;
     }
 }

--- a/auth/src/api/interfaces/database.ts
+++ b/auth/src/api/interfaces/database.ts
@@ -1,3 +1,7 @@
+import { Id } from 'src/core/key-transforms';
+
+export type KeyType = Id | string;
+
 export abstract class Database {
     public static readonly PREFIX = 'auth';
 
@@ -16,7 +20,7 @@ export abstract class Database {
      *
      * @returns A boolean, if everything is okay - if `false`, the key is already existing in the database.
      */
-    public abstract set<T>(key: string, obj: T): Promise<void>;
+    public abstract set<T>(key: KeyType, obj: T): Promise<void>;
 
     /**
      * This returns an object stored by the given key.
@@ -25,7 +29,7 @@ export abstract class Database {
      *
      * @returns The object - if there is no object stored by this key, it will return an empty object.
      */
-    public abstract get<T>(key: string): Promise<T>;
+    public abstract get<T>(key: KeyType): Promise<T>;
 
     /**
      * This will delete an entry from the database.
@@ -34,5 +38,5 @@ export abstract class Database {
      *
      * @returns A boolean if the object was successfully deleted.
      */
-    public abstract remove(key: string): Promise<boolean>;
+    public abstract remove(key: KeyType): Promise<boolean>;
 }

--- a/auth/src/api/interfaces/ticket-handler.ts
+++ b/auth/src/api/interfaces/ticket-handler.ts
@@ -1,3 +1,5 @@
+import { Id } from 'src/core/key-transforms';
+
 import { Cookie, Ticket, Token } from '../../core/ticket';
 import { JwtPayload } from '../../core/ticket/base-jwt';
 
@@ -19,7 +21,7 @@ export abstract class TicketHandler {
      *
      * @returns the new ticket
      */
-    public abstract create(userId: string, session: string): Ticket;
+    public abstract create(userId: Id, session: string): Ticket;
     /**
      * Creates a new instance of a `BaseJwt`. It is either a `Token` or a `Cookie`.
      *

--- a/auth/src/api/interfaces/user-handler.ts
+++ b/auth/src/api/interfaces/user-handler.ts
@@ -1,6 +1,8 @@
+import { Id } from 'src/core/key-transforms';
+
 import { User } from '../../core/models/user';
 
 export abstract class UserHandler {
     public abstract getUserByCredentials(username: string, password: string): Promise<User>;
-    public abstract getUserByUserId(userId: string): Promise<User>;
+    public abstract getUserByUserId(userId: Id): Promise<User>;
 }

--- a/auth/src/api/services/auth-service.ts
+++ b/auth/src/api/services/auth-service.ts
@@ -50,7 +50,7 @@ export class AuthService implements AuthHandler {
         if (!(await this._sessionHandler.hasSession(cookie.sessionId))) {
             throw new AuthenticationException('Not signed in');
         }
-        const user = await this._userHandler.getUserByUserId(cookie.userId as string);
+        const user = await this._userHandler.getUserByUserId(cookie.userId);
         if (!user) {
             await this._sessionHandler.clearSessionById(cookie.sessionId);
             throw new AuthenticationException('Wrong user');

--- a/auth/src/api/services/ticket-service.ts
+++ b/auth/src/api/services/ticket-service.ts
@@ -1,5 +1,6 @@
 import { Factory } from 'final-di';
 import jwt from 'jsonwebtoken';
+import { Id } from 'src/core/key-transforms';
 
 import { AuthenticationException } from '../../core/exceptions/authentication-exception';
 import { ValidationException } from '../../core/exceptions/validation-exception';
@@ -39,14 +40,14 @@ export class TicketService extends TicketHandler {
         }
     }
 
-    public create(userId: string, session: string): Ticket {
+    public create(userId: Id, session: string): Ticket {
         const cookie = this.generateCookie(session, userId);
         const token = this.generateToken(session, userId);
         return { cookie, token };
     }
 
     public refresh(cookie: Cookie): Ticket {
-        const token = this.generateToken(cookie.sessionId, cookie.userId as string);
+        const token = this.generateToken(cookie.sessionId, cookie.userId);
         return { cookie, token };
     }
 
@@ -92,16 +93,16 @@ export class TicketService extends TicketHandler {
     }
 
     private generateToken(payload: JwtPayload): Token;
-    private generateToken(sessionId: string, userId: string): Token;
-    private generateToken(sessionId: string | JwtPayload, userId?: string): Token {
+    private generateToken(sessionId: string, userId: Id): Token;
+    private generateToken(sessionId: string | JwtPayload, userId?: Id): Token {
         const payload: JwtPayload =
             typeof sessionId === 'string' && userId ? { sessionId, userId } : (sessionId as JwtPayload);
         return new Token(payload, this.tokenSecret, { expiresIn: '10m' });
     }
 
     private generateCookie(payload: JwtPayload): Cookie;
-    private generateCookie(sessionId: string, userId: string): Cookie;
-    private generateCookie(sessionId: string | JwtPayload, userId?: string): Cookie {
+    private generateCookie(sessionId: string, userId: Id): Cookie;
+    private generateCookie(sessionId: string | JwtPayload, userId?: Id): Cookie {
         const payload: JwtPayload =
             typeof sessionId === 'string' && userId ? { sessionId, userId } : (sessionId as JwtPayload);
         return new Cookie(payload, this.cookieSecret, { expiresIn: '30d' });

--- a/auth/src/config/index.ts
+++ b/auth/src/config/index.ts
@@ -11,9 +11,9 @@ export class Config {
     public static readonly DATABASE_PATH = 'database/';
     public static readonly DATASTORE_READER = getReaderUrl();
 
-    private static readonly VERBOSE_TRUE_FIELDS = ['1', 'y', 'yes', 'true', 'on'];
+    private static readonly VERBOSE_TRUE_FIELDS = ['1', 'true', 'on'];
 
     public static isDevMode(): boolean {
-        return this.VERBOSE_TRUE_FIELDS.includes(process.env.OPENSLIDES_DEVELOPMENT || '');
+        return this.VERBOSE_TRUE_FIELDS.includes((process.env.OPENSLIDES_DEVELOPMENT || '').toLowerCase());
     }
 }

--- a/auth/src/core/models/user.ts
+++ b/auth/src/core/models/user.ts
@@ -1,9 +1,11 @@
+import { Id } from '../key-transforms';
+
 export class User {
     public static readonly COLLECTION = 'user';
 
+    public readonly id: Id;
     public readonly username: string;
     public readonly password: string;
-    public readonly id: string;
     public readonly email: string;
     public readonly is_active: boolean;
     public readonly meta_deleted: boolean;

--- a/auth/src/core/ticket/base-jwt.ts
+++ b/auth/src/core/ticket/base-jwt.ts
@@ -1,13 +1,15 @@
 import { sign, SignOptions } from 'jsonwebtoken';
 
+import { Id } from '../key-transforms';
+
 export interface JwtPayload {
-    userId?: number | string;
+    userId?: Id;
     sessionId?: string;
     email?: string;
 }
 
 export abstract class BaseJwt {
-    public readonly userId: number | string;
+    public readonly userId: Id;
     public readonly sessionId: string;
     public readonly email: string;
 
@@ -20,7 +22,7 @@ export abstract class BaseJwt {
     ) {
         const options: SignOptions = { ...rawOptions, algorithm: rawOptions.algorithm ?? 'HS256' };
         this.rawToken = sign(payload, secret, options);
-        this.userId = payload.userId as string;
+        this.userId = payload.userId as Id;
         this.sessionId = payload.sessionId as string;
         this.email = payload.email as string;
     }


### PR DESCRIPTION
When users were accessed by id, the code used a `filter` operation instead of a simple `get`. Rectified that and fixed the typing of user ids in the process.