### PR TITLE
Use secret key when creating SP object

### DIFF
--- a/auth/src/express/controllers/saml-controller.ts
+++ b/auth/src/express/controllers/saml-controller.ts
@@ -196,7 +196,8 @@ export class SamlController {
                 Promise.resolve('skipped')
         });
         return samlify.ServiceProvider({
-            metadata: (await this.getSamlSettings()).saml_metadata_sp
+            metadata: (await this.getSamlSettings()).saml_metadata_sp,
+            privateKey: (await this.getSamlSettings()).saml_private_key
         });
     }
 


### PR DESCRIPTION
This allow requests to IdP to be signed/encrypted.